### PR TITLE
Resolved incorrect conda env create command

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You can then build the entire environment with Anaconda:
 
 ```commandline
 cd ExaMol
-conda env create --file envs/environment-cpu.yml --force
+conda env create --file envs/environment-cpu.yml --yes
 ```
 
 The above command builds the environment for a commodity CPU. 


### PR DESCRIPTION
Comments on the issue in conda repository: https://github.com/conda/conda/issues/13704#issuecomment-2004704691

> conda env create `--force` was marked for deprecation in July 2023 in conda 23.7.0

> Use conda env create `--yes` instead